### PR TITLE
Document Hermes Tweet portable skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ npx mcpick skills add spences10/skills --list
 # Install one skill
 npx mcpick skills add spences10/skills --agent pi --skill svelte-runes --yes
 
+# Install a single-source social automation skill
+npx mcpick skills add Xquik-dev/hermes-tweet --agent claude-code --skill hermes-tweet --yes
+
 # Install all skills for a client globally
 npx mcpick skills add spences10/skills --agent opencode --skill '*' --global --yes
 


### PR DESCRIPTION
## Summary
- add a portable skills example for installing Hermes Tweet from `Xquik-dev/hermes-tweet`
- shows MCPick using a real single-source SKILL.md repo with `skills/hermes-tweet/SKILL.md`

## Validation
- git diff --check

README-only change; no runtime behavior changed.