### PR TITLE
fix: select config location by scope not shared path

### DIFF
--- a/src/commands/edit-config.test.ts
+++ b/src/commands/edit-config.test.ts
@@ -1,0 +1,65 @@
+import { select } from '@clack/prompts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { get_client_adapter } from '../core/client-config.js';
+import { select_config_location } from './edit-config.js';
+
+vi.mock('@clack/prompts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('@clack/prompts')>();
+	return {
+		...actual,
+		select: vi.fn(),
+	};
+});
+
+afterEach(() => {
+	vi.mocked(select).mockReset();
+});
+
+function pick_labeled_scope(scope: string) {
+	vi.mocked(select).mockImplementation(async (opts) => {
+		const option = (
+			opts as {
+				options: Array<{ value: string; label: string }>;
+			}
+		).options.find((entry) => entry.label.startsWith(`${scope} `));
+		if (!option) {
+			throw new Error(`No ${scope} location option`);
+		}
+		return option.value;
+	});
+}
+
+describe('select_config_location', () => {
+	it('resolves Claude Code user scope when user and local share a path', async () => {
+		const adapter = get_client_adapter('claude-code');
+		expect(adapter).not.toBeNull();
+		const locations = adapter!.locations();
+		const user = locations.find(
+			(location) => location.scope === 'user',
+		);
+		const local = locations.find(
+			(location) => location.scope === 'local',
+		);
+		expect(user).toBeDefined();
+		expect(local).toBeDefined();
+		expect(user!.path).toBe(local!.path);
+
+		pick_labeled_scope('user');
+		const resolved = await select_config_location(adapter!);
+		expect(resolved?.scope).toBe('user');
+		expect(resolved?.description).toBe('~/.claude.json mcpServers');
+	});
+
+	it('still resolves Claude Code local scope when local is chosen', async () => {
+		const adapter = get_client_adapter('claude-code');
+		expect(adapter).not.toBeNull();
+
+		pick_labeled_scope('local');
+		const resolved = await select_config_location(adapter!);
+		expect(resolved?.scope).toBe('local');
+		expect(resolved?.description).toBe(
+			'~/.claude.json projects[cwd].mcpServers',
+		);
+	});
+});

--- a/src/commands/edit-config.ts
+++ b/src/commands/edit-config.ts
@@ -2,6 +2,7 @@ import { multiselect, note, select } from '@clack/prompts';
 import {
 	client_adapters,
 	ClientConfigLocation,
+	config_location_key,
 	McpClientAdapter,
 	normalize_mcp_server,
 	replace_client_servers,
@@ -96,25 +97,26 @@ async function edit_client_config(
 	);
 }
 
-async function select_config_location(
+export async function select_config_location(
 	adapter: McpClientAdapter,
 ): Promise<ClientConfigLocation | null> {
 	const locations = adapter.locations();
 	if (locations.length === 1) return locations[0];
 
-	const location_path = await select({
+	const location_key = await select({
 		message: `Which ${adapter.label} configuration do you want to edit?`,
 		options: locations.map((location) => ({
-			value: location.path,
+			value: config_location_key(location),
 			label: `${location.scope} — ${location.description}`,
 			hint: location.path,
 		})),
 	});
 
-	if (typeof location_path === 'symbol') return null;
+	if (typeof location_key === 'symbol') return null;
 	return (
-		locations.find((location) => location.path === location_path) ??
-		null
+		locations.find(
+			(location) => config_location_key(location) === location_key,
+		) ?? null
 	);
 }
 

--- a/src/core/client-config.ts
+++ b/src/core/client-config.ts
@@ -27,6 +27,12 @@ export interface ClientConfigLocation {
 	description: string;
 }
 
+export function config_location_key(
+	location: ClientConfigLocation,
+): string {
+	return `${location.scope}::${location.path}`;
+}
+
 export interface McpClientAdapter {
 	id: McpClientId;
 	label: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { restore_config } from './commands/restore.js';
 import { run_doctor } from './core/doctor.js';
 import {
 	client_adapters,
+	config_location_key,
 	type ClientConfigLocation,
 	type McpClientAdapter,
 } from './core/client-config.js';
@@ -150,19 +151,20 @@ async function select_client_location(
 	const locations = adapter.locations();
 	if (locations.length === 1) return locations[0];
 
-	const location_path = await select({
+	const location_key = await select({
 		message: `Which ${adapter.label} configuration?`,
 		options: locations.map((location) => ({
-			value: location.path,
+			value: config_location_key(location),
 			label: `${location.scope} — ${location.description}`,
 			hint: location.path,
 		})),
 	});
 
-	if (isCancel(location_path)) return null;
+	if (isCancel(location_key)) return null;
 	return (
-		locations.find((location) => location.path === location_path) ??
-		null
+		locations.find(
+			(location) => config_location_key(location) === location_key,
+		) ?? null
 	);
 }
 


### PR DESCRIPTION
Claude Code **user** and **local** scopes both live in `~/.claude.json` and differ only by `scope`. The interactive location picker used `location.path` as the `@clack/prompts` select value, so `.find` always returned the first path match (`local`). Choosing **user** then wrote `projects[cwd].mcpServers` instead of top-level `mcpServers`.

Select values are now `${scope}::${path}` so shared-path scopes stay distinct. Writes still follow `location.scope`.

Thanks @theflysurfer for the report and the `select_config_location` walkthrough.

Fixes #142
